### PR TITLE
Update 16_Vector concatenation operator.v

### DIFF
--- a/2_Verilog Language/2_Vectors/16_Vector concatenation operator.v
+++ b/2_Verilog Language/2_Vectors/16_Vector concatenation operator.v
@@ -3,11 +3,6 @@ module top_module (
     output [7:0] w, x, y, z
 );
 
-wire [31:0] concat;
-assign concat = {a, b, c, d, e, f, 2'b11};
-assign w = concat[31:24];
-assign x = concat[23:16];
-assign y = concat[15:8];
-assign z = concat[7:0];
+    assign {w,x,y,z} = {a,b,c,d,e,f,{2{1'b1}}};
 
 endmodule


### PR DESCRIPTION
wire [31:0] concat;
assign concat = {a, b, c, d, e, f, 2'b11};
assign w = concat[31:24];
assign x = concat[23:16];
assign y = concat[15:8];
assign z = concat[7:0];

This code has multiple lines of code. Also, putting values in w,x,y,z from the concat vector one by one is error prone. 

These whole lines of code can be summarized  in a single line:

assign {w,x,y,z} = {a,b,c,d,e,f,{2{1'b1}}};

This lets the system to take care of assigning the bits, we do not need to assign the values in the output vectors by splitting the concat vector. Also, it does not create a new vector, therefore uses less memory to run.